### PR TITLE
Typo in Markdown at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#![logo](logo.png)
+# ![logo](logo.png)
 
 ## Introduction
 


### PR DESCRIPTION
Your `README.md` is being rendered with an orphaned `#` on the top, because there was supposed to be a space between the `#` (which identifies the line as a H1 title) from the `![]()`, which creates an image. This PR fixes this mistake ([lhf](http://www.urbandictionary.com/define.php?term=low-hanging%20fruit) I know, but `¯\_(ツ)_/¯`)



Screenshot of the orphaned sharp below. [You can see the fixed `README.md` here.](https://github.com/joelwallis/magnetis-styleguide/tree/patch-1)

![captura de tela 2017-05-16 16 26 07](https://cloud.githubusercontent.com/assets/673884/26124308/64aa5d62-3a54-11e7-8efb-6c8a57eb49f3.png)